### PR TITLE
Time locked transactions will have higher fees

### DIFF
--- a/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs
+++ b/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs
@@ -608,13 +608,13 @@ namespace NTumbleBit.ClassicTumbler.Server.Controllers
             var cycle = GetCycle(cycleId);
 
             // TODO: Check if we actually want this to be "ConfigureAwait(false)"
-            var cashout = await Services.WalletService.GenerateAddressAsync().ConfigureAwait(false);
+            var cashoutAddress = await Services.WalletService.GenerateAddressAsync().ConfigureAwait(false);
             // Save the cashout destination internally.
-            session.ConfigureTumblerCashOutAddress(cashout.ScriptPubKey);
+            session.ConfigureTumblerCashOutAddress(cashoutAddress.ScriptPubKey);
             // TODO: Check if the Type of the address here is ok (it doesn't assume anything)
-            Tracker.AddressCreated(cycle.Start, TransactionType.ClientEscape, cashout.ScriptPubKey, correlation);
+            Tracker.AddressCreated(cycle.Start, TransactionType.ClientEscape, cashoutAddress.ScriptPubKey, correlation);
             // Send the cashout to Alice so that it can be used in the escape transaction.
-            fulfillKey.EscapeCashout = cashout.ScriptPubKey;
+            fulfillKey.EscapeCashout = cashoutAddress.ScriptPubKey;
             Repository.Save(cycleId, session);
 			return fulfillKey;
 		}

--- a/NTumbleBit/EscrowInitiator.cs
+++ b/NTumbleBit/EscrowInitiator.cs
@@ -31,7 +31,16 @@ namespace NTumbleBit
 				set;
 			}
 
-			public Script RedeemDestination
+            /// <summary>
+			/// Amount by which the transaction fee will be amplified.
+			/// </summary>
+            public int FeeFactor
+            {
+                get;
+                set;
+            } = 5;
+
+            public Script RedeemDestination
 			{
 				get;
 				set;
@@ -101,7 +110,9 @@ namespace NTumbleBit
 			// depends on what the escrowCoin had initially, so this value will follow whatever
 			// we initially set the escrow to have.
 			tx.Outputs.Add(new TxOut(escrowCoin.Amount, InternalState.RedeemDestination));
-			tx.Outputs[0].Value -= feeRate.GetFee(tx.GetVirtualSize());
+            
+            // We modify the fee here by the expected factor.
+			tx.Outputs[0].Value -= (feeRate.GetFee(tx.GetVirtualSize()) * InternalState.FeeFactor);
 
 			var redeemTransaction = new TrustedBroadcastRequest
 			{

--- a/NTumbleBit/EscrowReceiver.cs
+++ b/NTumbleBit/EscrowReceiver.cs
@@ -23,10 +23,19 @@ namespace NTumbleBit
 				set;
 			}
 
-			/// <summary>
-			/// Identify the channel to the tumbler
+            /// <summary>
+			/// Amount by which the transaction fee will be amplified.
 			/// </summary>
-			public uint160 ChannelId
+            public int FeeFactor
+            {
+                get;
+                set;
+            } = 5;
+
+            /// <summary>
+            /// Identify the channel to the tumbler
+            /// </summary>
+            public uint160 ChannelId
 			{
 				get;
 				set;

--- a/NTumbleBit/PuzzlePromise/PromiseClientSession.cs
+++ b/NTumbleBit/PuzzlePromise/PromiseClientSession.cs
@@ -314,11 +314,15 @@ namespace NTumbleBit.PuzzlePromise
                     Op.GetPushOp(InternalState.EscrowedCoin.Redeem.ToBytes())
                 );
                 cashout.Inputs[0].Witnessify();
+
                 var tumblerChange = InternalState.EscrowedCoin.Amount - ((i + 1) * Parameters.Denomination);
                 cashout.AddOutput(InternalState.EscrowedCoin.Amount - tumblerChange, cashoutDestination);
+
                 if (tumblerChange > Money.Zero)
                     cashout.AddOutput(tumblerChange, InternalState.TumblerCashoutDestination);
-                var cashoutFee = feeRate.GetFee(cashout.GetVirtualSize());
+
+                var cashoutFee = (feeRate.GetFee(cashout.GetVirtualSize()) * InternalState.FeeFactor);
+
                 cashout.Outputs[0].Value -= cashoutFee;
                 cashoutFees[i] = (uint) cashoutFee.Satoshi;
                 _cashouts[i] = cashout;

--- a/NTumbleBit/PuzzleSolver/SolverClientSession.cs
+++ b/NTumbleBit/PuzzleSolver/SolverClientSession.cs
@@ -404,7 +404,9 @@ namespace NTumbleBit.PuzzleSolver
 				Op.GetPushOp(TrustedBroadcastRequest.PlaceholderSignature),
 				Op.GetPushOp(InternalState.OfferCoin.Redeem.ToBytes()));
 			tx.Inputs[0].Witnessify();
-			tx.Outputs[0].Value -= feeRate.GetFee(tx.GetVirtualSize());
+
+            // Fee should be amplified since this redeem transaction will be spent in the future.
+			tx.Outputs[0].Value -= (feeRate.GetFee(tx.GetVirtualSize()) * InternalState.FeeFactor);
 
 			var redeemTransaction = new TrustedBroadcastRequest
 			{


### PR DESCRIPTION
Given that TumbleBit constructs transactions that are locktimed at some future heights, the transaction fees should be adjusted accordingly so that miners don't ignore the transactions due to the low fee.

Generally it is challenging to have an accurate estimate of a transaction fee at a future height, so the approach we are using to solve that problem is amplify the current fee estimation by a factor of `5`.
While this approach almost certainly over estimates the fee, it at least gurtantees that the transaction will not be rejected by miners when the locktime height is reached.

The transactions whose fees were amplified are the following:

- T_cashout that Bob uses to spend the money in T_escrow of the Tumbler (TransactionType.TumblerCashout):
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/PuzzlePromise/PromiseClientSession.cs#L324
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs#L576

- T_Redeem for T_escrow of the Tumbler (TransactionType.TumblerRedeem):
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/EscrowInitiator.cs#L115
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs#L369

- T_Redeem for T_escrow of Alice (TransactionType.ClientRedeem):
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/EscrowInitiator.cs#L115
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs#L301

- T_cash that the Tumbler uses to spend money in T_escrow of Alice (TransactionType.ClientEscape):
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/PuzzleSolver/SolverServerSession.cs#L531
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs#L726

- T_puzzle (T_offer) that gurantees the payment to Tumbler if it can provide T_solve with the puzzle solutions (TransactionType.ClientOffer):
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/PuzzleSolver/SolverServerSession.cs#L347
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs#L666

- T_solve (T_fulfill) provides the solutions to the puzzles in T_puzzle (TransactionType.ClientFulfill):
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/PuzzleSolver/SolverServerSession.cs#L482
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/ClassicTumbler/Server/Controllers/MainController.cs#L674

- T_Redeem for T_puzzle (T_offer) so that Alice can get back the money (TransactionType.ClientOfferRedeem):
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/PuzzleSolver/SolverClientSession.cs#L409
	- https://github.com/osagga/NTumbleBit/blob/177bcfc818a6091ca1de0340a297cb035cf2638b/NTumbleBit/ClassicTumbler/Client/PaymentStateMachine.cs#L562
